### PR TITLE
Add separate tsconfig for builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "lib/index.js",
   "scripts": {
     "start": "node lib/index.js",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "jest": "jest --config ./jest.config.json",
     "lint": "eslint 'src/**/*.ts'",
     "lint:fix": "eslint --fix 'src/**/*.ts'",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.json",
+    "exclude": [
+        "**/*.test.ts"
+    ]
+}


### PR DESCRIPTION
Use a separate Typescript configuration for builds, to avoid building tests unnecessarily.